### PR TITLE
fix: prevent error from other websockets closing

### DIFF
--- a/w.lua
+++ b/w.lua
@@ -94,8 +94,10 @@ function init(jua)
 
     jua.on("websocket_closed", function(event, url)
       local id = findID(url)
-      if id and callbackRegistry[id].closed then
-        callbackRegistry[id].closed(id)
+      if id then
+        if callbackRegistry[id].closed then
+          callbackRegistry[id].closed(id)
+        end
         table.remove(callbackRegistry, id)
       end
     end)
@@ -121,8 +123,10 @@ function init(jua)
     end)
 
     jua.on("socket_closed", function(event, id)
-      if id and callbackRegistry[id].closed then
-        callbackRegistry[id].closed(id)
+      if id then
+        if callbackRegistry[id].closed then
+          callbackRegistry[id].closed(id)
+        end
         table.remove(callbackRegistry, id)
       end
     end)

--- a/w.lua
+++ b/w.lua
@@ -79,10 +79,12 @@ function init(jua)
 
     jua.on("websocket_failure", function(event, url)
       local id = findID(url)
-      if id and callbackRegistry[id].failure then
-        callbackRegistry[id].failure(id)
+      if id then
+        if callbackRegistry[id].failure then
+          callbackRegistry[id].failure(id)
+        end
+        table.remove(callbackRegistry, id)
       end
-      table.remove(callbackRegistry, id)
     end)
 
     jua.on("websocket_message", function(event, url, data)
@@ -109,10 +111,12 @@ function init(jua)
     end)
 
     jua.on("socket_error", function(event, id, msg)
-      if id and callbackRegistry[id].failure then
-        callbackRegistry[id].failure(id, msg)
+      if id then
+        if callbackRegistry[id].failure then
+          callbackRegistry[id].failure(id, msg)
+        end
+        table.remove(callbackRegistry, id)
       end
-      table.remove(callbackRegistry, id)
     end)
 
     jua.on("socket_message", function(event, id)

--- a/w.lua
+++ b/w.lua
@@ -96,8 +96,8 @@ function init(jua)
       local id = findID(url)
       if id and callbackRegistry[id].closed then
         callbackRegistry[id].closed(id)
+        table.remove(callbackRegistry, id)
       end
-      table.remove(callbackRegistry, id)
     end)
   else
     jua.on("socket_connect", function(event, id)
@@ -123,8 +123,8 @@ function init(jua)
     jua.on("socket_closed", function(event, id)
       if id and callbackRegistry[id].closed then
         callbackRegistry[id].closed(id)
+        table.remove(callbackRegistry, id)
       end
-      table.remove(callbackRegistry, id)
     end)
   end
 end


### PR DESCRIPTION
The table.remove call was left outside of the if block, so if the id was nil (which happens when there is another websocket running not handled by w.lua) then the table.remove call would error.

(I noticed that there is still code to handle legacy CCTweaks websockets. Is that worth keeping?)